### PR TITLE
Add dropout in BaseNN introduction

### DIFF
--- a/source/basenn/introduction.md
+++ b/source/basenn/introduction.md
@@ -510,7 +510,7 @@ model.add(optimizer='SGD') # 设定优化器
 
 参数:
 
-layer：层的类型，可选值包括Conv2D, MaxPool, AvgPool, Linear。
+layer：层的类型，可选值包括Conv2D, MaxPool, AvgPool, Linear, Dropout。
 
 activation：激活函数类型，可选值包括ReLU，Softmax。
 
@@ -527,6 +527,8 @@ maxpool：最大池化层，需给定kernel_size。
 avgpool：平均池化层，需给定kernel_size。
 
 linear：线性层，需给定size。
+
+dropout：随机失活层，需给定p（概率）。
 
 再以RNN模型（循环神经网络）为例进行详细说明：
 

--- a/source/basenn/introduction.rst
+++ b/source/basenn/introduction.rst
@@ -568,7 +568,7 @@ BaseNN中提供了一个CNN特征提取工具，可使用BaeNN的\ ``model.extra
 
 参数:
 
-layer：层的类型，可选值包括Conv2D, MaxPool, AvgPool, Linear。
+layer：层的类型，可选值包括Conv2D, MaxPool, AvgPool, Linear, Dropout。
 
 activation：激活函数类型，可选值包括ReLU，Softmax。
 
@@ -586,6 +586,8 @@ maxpool：最大池化层，需给定kernel_size。
 avgpool：平均池化层，需给定kernel_size。
 
 linear：线性层，需给定size。
+
+dropout：随机失活层，需给定p（概率）。
 
 再以RNN模型（循环神经网络）为例进行详细说明：
 


### PR DESCRIPTION
之前尝试添加dropout层，在layer里输入'dropout’后看到`增加dropout层,参数置零的概率为: 0.5`，但查阅文档发现没有关于添加dropout层，设置概率的描述，于是去查看源代码
```
elif layer == 'dropout':
    p = 0.5 if 'p' not in kw.keys() else kw['p']
    self.model.add_module('dropout' + str(self.layers_num), torch.nn.Dropout(p=p) )
    print("增加dropout层,参数置零的概率为: {} ".format(p))
```
看到通过p参数设置概率。

个人认为写入文档对使用者更加便利。
如果有错误，希望能够指出，谢谢！